### PR TITLE
Networking docs + relay/daemon scaffolding (compile fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.idea
 .DS_Store
 Cargo.lock
+.tmp/*

--- a/crates/mux-cli/Cargo.toml
+++ b/crates/mux-cli/Cargo.toml
@@ -5,9 +5,14 @@ edition = "2021"
 
 [dependencies]
 anyhow = { workspace = true }
-tokio = { workspace = true }
-tracing = { workspace = true }
+clap = { workspace = true }
+futures = { workspace = true }
 mux-acp = { path = "../mux-acp" }
 mux-planner = { path = "../mux-planner" }
 mux-telemetry = { path = "../mux-telemetry" }
 mux-config = { path = "../mux-config" }
+tokio = { workspace = true }
+tokio-util = { version = "0.7", features = ["codec"] }
+tokio-tungstenite = "0.21"
+tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
+tracing = { workspace = true }

--- a/crates/mux-cli/src/bin/mux-agentd.rs
+++ b/crates/mux-cli/src/bin/mux-agentd.rs
@@ -1,0 +1,35 @@
+use futures::{SinkExt, StreamExt};
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::protocol::Message;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    mux_telemetry::init();
+    let listener = TcpListener::bind("0.0.0.0:7777").await?;
+    tracing::info!("mux-agentd listening on 0.0.0.0:7777");
+
+    while let Ok((stream, addr)) = listener.accept().await {
+        tracing::info!("connection from {addr}");
+        tokio::spawn(async move {
+            let ws = tokio_tungstenite::accept_async(stream).await?;
+            let (mut sink, mut source) = ws.split();
+
+            // Echo loop for now — replace with ACP loop
+            while let Some(msg) = source.next().await {
+                match msg? {
+                    Message::Text(s) => sink.send(Message::Text(s)).await?,
+                    Message::Binary(b) => sink.send(Message::Binary(b)).await?,
+                    Message::Close(c) => {
+                        sink.send(Message::Close(c)).await.ok();
+                        break;
+                    }
+                    Message::Ping(p) => sink.send(Message::Pong(p)).await?,
+                    _ => {}
+                }
+            }
+            Ok::<(), anyhow::Error>(())
+        });
+    }
+
+    Ok(())
+}

--- a/crates/mux-cli/src/bin/mux-cli-relay.rs
+++ b/crates/mux-cli/src/bin/mux-cli-relay.rs
@@ -1,0 +1,57 @@
+use clap::Parser;
+use futures::{SinkExt, StreamExt};
+use tokio::io::{stdin, stdout};
+use tokio_tungstenite::tungstenite::protocol::Message;
+use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec};
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// Relay to remote agent (ws://, wss://, or tcp://)
+    #[arg(long)]
+    relay: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    mux_telemetry::init();
+    let args = Args::parse();
+    relay_stdio_over_ws(&args.relay).await
+}
+
+async fn relay_stdio_over_ws(url: &str) -> anyhow::Result<()> {
+    let (ws_stream, _) = tokio_tungstenite::connect_async(url).await?;
+    let (mut ws_sink, mut ws_stream) = ws_stream.split();
+
+    let mut stdin_lines = FramedRead::new(stdin(), LinesCodec::new());
+    let mut stdout_lines = FramedWrite::new(stdout(), LinesCodec::new());
+
+    // forward stdin -> WebSocket
+    let fwd = async {
+        while let Some(line) = stdin_lines.next().await {
+            let line = line?;
+            ws_sink.send(Message::Text(line)).await?;
+        }
+        let _ = ws_sink.send(Message::Close(None)).await;
+        Ok::<_, anyhow::Error>(())
+    };
+
+    // backward WebSocket -> stdout
+    let bwd = async {
+        while let Some(msg) = ws_stream.next().await {
+            match msg? {
+                Message::Text(s) => stdout_lines.send(s).await?,
+                Message::Binary(bin) => {
+                    stdout_lines
+                        .send(String::from_utf8_lossy(&bin).into_owned())
+                        .await?
+                }
+                Message::Close(_) => break,
+                _ => {}
+            }
+        }
+        Ok::<_, anyhow::Error>(())
+    };
+
+    tokio::try_join!(fwd, bwd)?;
+    Ok(())
+}

--- a/crates/mux-cli/src/main.rs
+++ b/crates/mux-cli/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
-use mux_acp::{Server};
-use mux_acp::Request;
+use mux_acp::Server;
 use mux_telemetry as telemetry;
 use tokio::io::{stdin, stdout};
 use tracing::info;

--- a/crates/mux-drivers/mux-driver-vllm/src/lib.rs
+++ b/crates/mux-drivers/mux-driver-vllm/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use futures::{stream, StreamExt};
-use mux_drivers::{Driver, ChatRequest, ChatChunk};
+use futures::stream;
+use mux_drivers::{ChatChunk, ChatRequest, Driver};
 use mux_router::ModelSpec;
 use std::sync::Arc;
 
@@ -10,7 +10,9 @@ pub struct VllmDriver {
 
 impl VllmDriver {
     pub fn new(endpoint: String) -> Arc<Self> {
-        Arc::new(Self { _endpoint: endpoint })
+        Arc::new(Self {
+            _endpoint: endpoint,
+        })
     }
 }
 
@@ -23,8 +25,14 @@ impl Driver for VllmDriver {
     ) -> Result<futures::stream::BoxStream<'static, Result<ChatChunk>>> {
         // Stub: return a tiny stream
         let s = stream::iter(vec![
-            Ok(ChatChunk{ text: "hello from vllm stub".into(), done: false }),
-            Ok(ChatChunk{ text: "".into(), done: true }),
+            Ok(ChatChunk {
+                text: "hello from vllm stub".into(),
+                done: false,
+            }),
+            Ok(ChatChunk {
+                text: "".into(),
+                done: true,
+            }),
         ]);
         Ok(Box::pin(s))
     }

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,0 +1,121 @@
+# Networking & Remote Agents
+
+`mux` speaks ACP (JSON-per-line over stdio) to editors like Zed.
+This doc covers running the heavy agent remotely while Zed still talks stdio locally.
+
+## Topology
+
+```
+Zed ──(stdio JSON lines)── mux-cli / mux-cli-relay
+                     │
+                     └── WebSocket/TCP ──► mux-agentd (remote)
+```
+
+- **Local mode**: `mux-cli` runs the ACP loop locally (no network).
+- **Relay mode**: `mux-cli-relay` pipes stdio ⇄ WebSocket/TCP.
+- **Daemon**: `mux-agentd` accepts WebSocket (and optionally stdio) and runs the same ACP loop.
+
+## Binaries
+
+- `mux-cli` — local ACP (what Zed launches by default).
+- `mux-cli-relay` — stdio ⇄ WebSocket/TCP bridge.
+- `mux-agentd` — remote WebSocket daemon.
+
+## Quick Start
+
+### Local (no network)
+```bash
+# Zed launches this:
+mux-cli
+```
+
+### Relay → Daemon (same host for demo)
+```bash
+# terminal A (server)
+cargo run -p mux-cli --bin mux-agentd -- --listen 0.0.0.0:7777
+
+# terminal B (client relay)
+cargo run -p mux-cli --bin mux-cli-relay -- --relay ws://127.0.0.1:7777
+```
+
+Point Zed to `mux-cli-relay` (see examples below).
+
+## Transport
+
+- **Framing**: one JSON message per line (UTF-8), end with `\n`.
+- **WS Ping/Pong**: client sends ping ~every 20s; drop connection on missed pong.
+- **Max frame size**: configurable; chunk large diffs into multiple messages.
+
+## Reliability
+
+- **Reconnect**: exponential backoff in the relay (250ms → 10s cap).
+- **Bounded channels**: between stdio and WS tasks to avoid unbounded memory.
+- **Backpressure**: pause reads when peer is slow; optionally drop/merge low-prio logs.
+
+## Security
+
+- Prefer **wss://** (TLS via rustls).
+- **Auth**: bearer token via header or `Sec-WebSocket-Protocol`.
+- **mTLS** (optional): client certs; pin CA on server side.
+- **Workspace allowlists**: daemon enforces permitted roots for file ops.
+- **Redaction**: never log secrets; scrub headers/tokens in logs.
+
+## Configuration (proposed)
+
+Relay client:
+```bash
+mux-cli-relay \
+  --relay wss://agent.example:7777/agent \
+  --relay-timeout 10s \
+  --relay-max-frame 1MiB \
+  --relay-token-file /etc/mux/token
+```
+
+Daemon:
+```bash
+mux-agentd \
+  --listen 0.0.0.0:7777 \
+  --tls-cert /etc/mux/tls/cert.pem \
+  --tls-key /etc/mux/tls/key.pem \
+  --token-file /etc/mux/token \
+  --workspace-allow /srv/repos \
+  --idle-timeout 5m
+```
+
+Environment overrides (examples):
+```
+MUX_RELAY_URL=…
+MUX_RELAY_TOKEN=…
+MUX_TLS_CERT=…
+MUX_TLS_KEY=…
+MUX_WORKSPACE_ALLOW=/srv/repos:/opt/code
+```
+
+## Systemd (example)
+
+`/etc/systemd/system/mux-agentd.service`:
+```ini
+[Unit]
+Description=mux agent daemon
+After=network-online.target
+
+[Service]
+User=mux
+Group=mux
+ExecStart=/usr/local/bin/mux-agentd --listen 0.0.0.0:7777 --tls-cert /etc/mux/tls/cert.pem --tls-key /etc/mux/tls/key.pem --token-file /etc/mux/token --workspace-allow /srv/repos
+Restart=on-failure
+Environment=RUST_LOG=info
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Zed Integration
+
+See `examples/zed/settings-local.jsonc` and `examples/zed/settings-relay.jsonc`.
+
+## Troubleshooting
+
+- **Handshake fails**: verify TLS cert/key and that the client trusts the CA.
+- **Drops under load**: increase bounded channel sizes, enable per-message deflate.
+- **High p95**: ensure model weights are staged to local NVMe on the daemon host.

--- a/examples/zed/settings-local.jsonc
+++ b/examples/zed/settings-local.jsonc
@@ -1,0 +1,11 @@
+{
+  "agent_servers": {
+    "Beast ACP (mux, local)": {
+      "command": "/usr/local/bin/mux-cli",
+      "env": {
+        "MODELS_CONFIG": "/etc/mux/models.yaml",
+        "RUST_LOG": "info"
+      }
+    }
+  }
+}

--- a/examples/zed/settings-relay.jsonc
+++ b/examples/zed/settings-relay.jsonc
@@ -1,0 +1,13 @@
+{
+  "agent_servers": {
+    "Beast ACP (mux, relay)": {
+      "command": "/usr/local/bin/mux-cli-relay",
+      "args": ["--relay", "wss://agent.example:7777/agent"],
+      "env": {
+        "MODELS_CONFIG": "/etc/mux/models.yaml",
+        "MUX_RELAY_TOKEN": "use-an-env-or-file-not-the-literal-value",
+        "RUST_LOG": "info"
+      }
+    }
+  }
+}

--- a/script/gh-issues.sh
+++ b/script/gh-issues.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${REPO:-qapish/mux}"
+
+# ---------- helpers ----------
+upsert_label () {
+  local name="$1" color="$2" desc="${3:-}"
+  if gh label create "$name" -R "$REPO" --color "$color" --description "$desc" >/dev/null 2>&1; then
+    echo "Created label: $name"
+  else
+    gh label edit "$name" -R "$REPO" --color "$color" ${desc:+--description "$desc"} >/dev/null
+    echo "Updated label: $name"
+  fi
+}
+
+# Create milestone by title if missing. Returns nothing; we pass title to gh later.
+ensure_milestone () {
+  local title="$1" desc="${2:-}" state="${3:-open}"
+  local found
+  found="$(gh api -X GET -F state=all "repos/${REPO}/milestones" --jq ".[] | select(.title==\"${title}\") | .title" || true)"
+  if [[ -z "$found" ]]; then
+    gh api -X POST "repos/${REPO}/milestones" \
+      -f title="$title" -f state="$state" -f description="$desc" --silent >/dev/null
+    echo "Created milestone: $title"
+  else
+    echo "Milestone exists: $title"
+  fi
+}
+
+# Create an issue under a milestone (by TITLE) with labels.
+issue () {
+  local title="$1"; shift
+  local labels_csv="$1"; shift
+  local milestone_title="$1"; shift
+
+  # ensure milestone exists
+  ensure_milestone "$milestone_title"
+
+  local label_args=()
+  IFS=',' read -ra LBL <<<"$labels_csv"
+  for l in "${LBL[@]}"; do [[ -n "$l" ]] && label_args+=(-l "$l"); done
+
+  gh issue create -R "$REPO" -t "$title" \
+    --milestone "$milestone_title" \
+    "${label_args[@]}" \
+    -b "$(cat)"
+}
+
+echo "==> Target repo: $REPO"
+echo "==> Ensuring labels…"
+
+# Areas
+upsert_label "area/acp"       "ededed" "ACP protocol + JSON-RPC/stdio"
+upsert_label "area/router"    "ededed" "Model registry, routing, residency"
+upsert_label "area/drivers"   "ededed" "Sidecar & embedded drivers"
+upsert_label "area/fs"        "ededed" "Staging, cache, integrity"
+upsert_label "area/planner"   "ededed" "Planning loop, tools, prompts"
+upsert_label "area/diff"      "ededed" "Diff/patch generation & apply"
+upsert_label "area/telemetry" "ededed" "Tracing, metrics, logs"
+upsert_label "area/ci"        "ededed" "CI/CD, release, packaging"
+upsert_label "area/security"  "ededed" "Policy, sandboxing, supply chain"
+
+# Types & Priority
+upsert_label "type/enhancement" "84b6eb" "Feature work"
+upsert_label "type/bug"         "ee0701" "Defects"
+upsert_label "priority/P1"      "e11d21" "High urgency"
+upsert_label "priority/P2"      "eb6420" "Medium"
+upsert_label "priority/P3"      "fbca04" "Low"
+
+echo "==> Ensuring milestones…"
+M_FOUNDATIONS="Foundations"
+M_ACP_MVP="ACP MVP"
+M_ROUTER_DRIVERS="Router & Drivers"
+M_STAGING="Staging & Residency"
+M_PLANNER="Planner v1"
+M_TELEMETRY="Telemetry & Stability"
+M_PERF="Performance Track"
+M_CANDLE="Candle Driver"
+M_ACP_COMPLETE="ACP Complete"
+M_RELEASE="Release"
+M_FUTURE="Future Work"
+
+ensure_milestone "$M_FOUNDATIONS"        "Bootstrap, hygiene, CI"
+ensure_milestone "$M_ACP_MVP"            "ACP transport + editor loop MVP"
+ensure_milestone "$M_ROUTER_DRIVERS"     "Router, registry, sidecar drivers"
+ensure_milestone "$M_STAGING"            "NFS→NVMe staging & GPU residency"
+ensure_milestone "$M_PLANNER"            "Planner v1: context, diffs"
+ensure_milestone "$M_TELEMETRY"          "Observability, limits, stability"
+ensure_milestone "$M_PERF"               "Scheduler, KV, kernels, throughput"
+ensure_milestone "$M_CANDLE"             "Pure-Rust inference driver"
+ensure_milestone "$M_ACP_COMPLETE"       "Full ACP surface coverage"
+ensure_milestone "$M_RELEASE"            "Packaging, docs, releases"
+ensure_milestone "$M_FUTURE"             "Nice-to-haves & future work"
+
+echo "==> Creating issues (grouped by milestone)…"
+
+# ---------- Foundations
+issue "Repo hygiene: CODE_OF_CONDUCT, CONTRIBUTING, SECURITY" \
+      "area/ci,type/enhancement,priority/P3" "$M_FOUNDATIONS" <<'EOF'
+Add baseline project docs:
+- [ ] CODE_OF_CONDUCT.md
+- [ ] CONTRIBUTING.md (workflow, style, PR checklist)
+- [ ] SECURITY.md (reporting, supported versions)
+EOF
+
+issue "CI: Build, test, clippy -D warnings, fmt --check" \
+      "area/ci,type/enhancement,priority/P2" "$M_FOUNDATIONS" <<'EOF'
+Set up GitHub Actions:
+- [ ] Linux x86_64 build matrix (stable)
+- [ ] Cache cargo/target
+- [ ] Run tests
+- [ ] Run clippy with `-D warnings`
+- [ ] Run `cargo fmt --check`
+Artifacts (optional): debug binaries per PR.
+EOF
+
+# ---------- ACP MVP
+issue "ACP transport MVP: JSON-RPC over stdio" \
+      "area/acp,type/enhancement,priority/P1" "$M_ACP_MVP" <<'EOF'
+Deliver ACP MVP:
+- [ ] Request/response envelopes with ids and errors
+- [ ] Heartbeat (`ping`/`pong`)
+- [ ] Streamed progress/log events
+- [ ] Backpressure-safe framing
+EOF
+
+issue "Workspace ops (minimal): read/write/apply_patch/list_files" \
+      "area/acp,area/diff,type/enhancement,priority/P1" "$M_ACP_MVP" <<'EOF'
+Implement editor-facing ops:
+- [ ] `read_file`, `write_file`, `apply_patch`
+- [ ] `list_files` (repo-scoped, obey ignore rules)
+- [ ] Unit tests and golden patch tests
+EOF
+
+issue "Planner stub: synthetic plan/patch for Zed review UI" \
+      "area/planner,type/enhancement,priority/P2" "$M_ACP_MVP" <<'EOF'
+- [ ] Minimal planner returning a single-file synthetic patch
+- [ ] Tracing spans for each ACP request
+- [ ] Verify Zed Agent Panel review/apply flow
+EOF
+
+issue "Zed integration example & docs" \
+      "area/acp,area/ci,type/enhancement,priority/P2" "$M_ACP_MVP" <<'EOF'
+- [ ] Provide `settings.json` snippet for Zed Agent Panel
+- [ ] Capture ACP logs for a demo session
+- [ ] Troubleshooting section in README
+EOF
+
+# ---------- Router & Drivers
+issue "Config: models.yaml schema + validator" \
+      "area/router,type/enhancement,priority/P1" "$M_ROUTER_DRIVERS" <<'EOF'
+Define and validate model entries:
+- [ ] name, path, backend, tokenizer, quant, max_ctx
+- [ ] clear error messages
+- [ ] example fixtures
+EOF
+
+issue "Router core: driver trait, registry, health checks" \
+      "area/router,type/enhancement,priority/P1" "$M_ROUTER_DRIVERS" <<'EOF'
+- [ ] `Driver` trait with streaming API
+- [ ] registry for backends
+- [ ] readiness/health check contracts
+- [ ] simple residency hook: `ensure_loaded` / `unload`
+EOF
+
+issue "Driver: llama.cpp (OpenAI server) with streaming" \
+      "area/drivers,type/enhancement,priority/P1" "$M_ROUTER_DRIVERS" <<'EOF'
+- [ ] Connect to `llama-server` in OpenAI mode
+- [ ] SSE / chunked streaming to editor
+- [ ] Timeout & cancellation handling
+EOF
+
+issue "Driver: vLLM sidecar (optional) with process orchestration" \
+      "area/drivers,type/enhancement,priority/P3" "$M_ROUTER_DRIVERS" <<'EOF'
+- [ ] Spawn/monitor vLLM server for a model
+- [ ] Health/readiness probe
+- [ ] Graceful shutdown
+EOF
+
+issue "Planner→model integration: streaming chat/completions" \
+      "area/planner,area/drivers,type/enhancement,priority/P2" "$M_ROUTER_DRIVERS" <<'EOF'
+- [ ] `ChatRequest` with system/user messages
+- [ ] Token streaming to ACP events
+- [ ] Backpressure and cancellation
+EOF
+
+# ---------- Staging & Residency
+issue "Staging pipeline: NFS → NVMe (CAS), integrity, resume" \
+      "area/fs,type/enhancement,priority/P1" "$M_STAGING" <<'EOF'
+- [ ] Content-addressed store (SHA256)
+- [ ] File locks, temp names, atomic move
+- [ ] Resume partial downloads
+- [ ] Hash/size integrity verification
+EOF
+
+issue "VRAM residency: LRU, clean unload, prewarm hooks" \
+      "area/router,type/enhancement,priority/P1" "$M_STAGING" <<'EOF'
+- [ ] Per-GPU LRU of active models
+- [ ] Clean unload of weights & KV pools
+- [ ] Pre-warm idle models policy hooks
+EOF
+
+issue "Topology awareness: GPU inventory & pinning policy" \
+      "area/router,type/enhancement,priority/P2" "$M_STAGING" <<'EOF'
+- [ ] CUDA/ROCm inventory probe
+- [ ] Model→GPU pinning config
+- [ ] Per-process isolation defaults
+EOF
+
+# ---------- Planner v1
+issue "Repo context: file graph + ripgrep search" \
+      "area/planner,type/enhancement,priority/P2" "$M_PLANNER" <<'EOF'
+- [ ] Snapshot file graph with ignore rules
+- [ ] ripgrep integration for code search
+- [ ] Heuristics for language relevance
+EOF
+
+issue "Edit production: plan→multi-file unified diff + safe apply" \
+      "area/diff,area/planner,type/enhancement,priority/P1" "$M_PLANNER" <<'EOF'
+- [ ] Prompt templates for plan/diff production
+- [ ] Multi-file unified diff generation
+- [ ] Conflict-aware apply with backup/rollback
+EOF
+
+issue "Function-calling (optional): tools → ACP ops" \
+      "area/planner,type/enhancement,priority/P3" "$M_PLANNER" <<'EOF'
+- [ ] Tool schema: read_files, search, propose_patch, run_shell(guarded)
+- [ ] Translate tool calls to ACP workspace ops
+EOF
+
+# ---------- Telemetry & Stability
+issue "Observability: tracing + Prometheus metrics" \
+      "area/telemetry,type/enhancement,priority/P2" "$M_TELEMETRY" <<'EOF'
+- [ ] Request ids & spans per module
+- [ ] Metrics: token/s, queue depth, GPU mem, p50/p95/p99
+- [ ] JSON logs toggle via env
+EOF
+
+issue "Quotas, limits, and stability" \
+      "area/telemetry,type/enhancement,priority/P2" "$M_TELEMETRY" <<'EOF'
+- [ ] Max tokens/time per session
+- [ ] Sandboxed shell runner (denylist & cwd jail)
+- [ ] Retries/backoff for sidecars
+- [ ] Graceful cancellation on editor disconnect
+EOF
+
+# ---------- Performance Track
+issue "Scheduler (continuous/inflight batching)" \
+      "area/router,type/enhancement,priority/P1" "$M_PERF" <<'EOF'
+- [ ] Prefill vs decode scheduling
+- [ ] Prompt dedup & prefix caching
+- [ ] Bench harness for throughput/latency
+EOF
+
+issue "KV cache (paged allocator & accounting)" \
+      "area/router,type/enhancement,priority/P1" "$M_PERF" <<'EOF'
+- [ ] Paged KV abstraction
+- [ ] Memory accounting per session/model
+- [ ] Integration with residency policy
+EOF
+
+issue "Attention kernels via FFI (FlashAttention-class)" \
+      "area/drivers,type/enhancement,priority/P2" "$M_PERF" <<'EOF'
+- [ ] FFI to C++/CUDA kernels
+- [ ] Benchmarks & golden tests
+- [ ] Feature gate
+EOF
+
+# ---------- Candle Driver
+issue "Candle driver: pure-Rust inference path" \
+      "area/drivers,type/enhancement,priority/P2" "$M_CANDLE" <<'EOF'
+- [ ] safetensors mmap + tokenizer
+- [ ] Streaming + cancellation
+- [ ] Reuse scheduler/KV abstractions
+- [ ] Parity tests vs sidecars
+EOF
+
+# ---------- ACP Complete
+issue "ACP: full surface (multi-buffer, rename/move, templates)" \
+      "area/acp,type/enhancement,priority/P2" "$M_ACP_COMPLETE" <<'EOF'
+- [ ] Multi-buffer edits
+- [ ] Rename/move/create/delete
+- [ ] Long-running task progress & cancellation
+- [ ] Agent state persistence between turns
+EOF
+
+# ---------- Release
+issue "Packaging & release (static builds, docs, examples)" \
+      "area/ci,type/enhancement,priority/P2" "$M_RELEASE" <<'EOF'
+- [ ] Static builds (musl where feasible), jemalloc toggle
+- [ ] Version embedding (git sha)
+- [ ] Example models.yaml and Zed settings
+- [ ] Release notes + checksums + SBOM
+EOF
+
+# ---------- Future Work
+issue "Benchmark suite: micro + macro SLAs" \
+      "area/telemetry,type/enhancement,priority/P2" "$M_FUTURE" <<'EOF'
+- [ ] Tokenization speed, prefill/decode tokens/s
+- [ ] Latency per token (stream jitter)
+- [ ] Repo-wide refactor timing under load
+- [ ] Concurrency p50/p95/p99 targets
+EOF
+
+issue "Security & supply chain: cargo-deny, secret redaction, sandbox" \
+      "area/security,type/enhancement,priority/P2" "$M_FUTURE" <<'EOF'
+- [ ] cargo-deny audit
+- [ ] Redact secrets in logs
+- [ ] Sandboxed shell & path allowlists
+- [ ] Network egress allowlist for sidecars
+EOF
+
+echo "==> Done. 🎯"

--- a/script/gh-networking-core.sh
+++ b/script/gh-networking-core.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${REPO:-qapish/mux}"
+M_NET="Networking & Remote Agents"
+
+echo "==> Target repo: $REPO"
+
+# -- helpers ---------------------------------------------------------------
+
+upsert_label () {
+  local name="$1" color="$2" desc="${3:-}"
+  if gh label create "$name" -R "$REPO" --color "$color" --description "$desc" >/dev/null 2>&1; then
+    echo "Created label: $name"
+  else
+    gh label edit "$name" -R "$REPO" --color "$color" ${desc:+--description "$desc"} >/dev/null
+    echo "Updated label: $name"
+  fi
+}
+
+ensure_milestone () {
+  local title="$1" desc="${2:-}" state="${3:-open}"
+  local found
+  found="$(gh api -X GET -F state=all "repos/${REPO}/milestones" --jq ".[] | select(.title==\"${title}\") | .title" || true)"
+  if [[ -z "$found" ]]; then
+    gh api -X POST "repos/${REPO}/milestones" -f title="$title" -f state="$state" -f description="$desc" --silent >/dev/null
+    echo "Created milestone: $title"
+  else
+    echo "Milestone exists: $title"
+  fi
+}
+
+issue () {
+  local title="$1"; shift
+  local labels_csv="$1"; shift
+  local milestone_title="$1"; shift
+
+  ensure_milestone "$milestone_title"
+
+  local label_args=()
+  IFS=',' read -ra LBL <<<"$labels_csv"
+  for l in "${LBL[@]}"; do [[ -n "$l" ]] && label_args+=(-l "$l"); done
+
+  gh issue create -R "$REPO" -t "$title" \
+    --milestone "$milestone_title" \
+    "${label_args[@]}" \
+    -b "$(cat)"
+}
+
+# -- labels & milestone ----------------------------------------------------
+
+echo "==> Ensuring labels…"
+upsert_label "area/network"   "ededed" "Relay, sockets, WS/TCP"
+upsert_label "area/acp"       "ededed" "ACP protocol & stdio framing"
+upsert_label "area/security"  "ededed" "Auth, TLS, sandboxing"
+upsert_label "area/docs"      "ededed" "Docs & examples"
+upsert_label "area/telemetry" "ededed" "Tracing, metrics, logs"
+upsert_label "type/enhancement" "84b6eb" "Feature work"
+upsert_label "priority/P1"      "e11d21" "High urgency"
+upsert_label "priority/P2"      "eb6420" "Medium"
+
+echo "==> Ensuring milestone…"
+ensure_milestone "$M_NET" "Remote agent support: relay (stdio⇄WebSocket/TCP) and agent daemon"
+
+# -- issues ---------------------------------------------------------------
+
+issue "Implement mux-cli-relay: stdio ⇄ WebSocket/TCP" \
+      "area/network,area/acp,type/enhancement,priority/P1" "$M_NET" <<'EOF'
+Build a relay client as a separate binary:
+- [ ] New bin: `mux-cli-relay` under `crates/mux-cli/src/bin/`
+- [ ] Flag: `--relay <ws://|wss://|tcp://>`
+- [ ] Line-delimited JSON framing both directions
+- [ ] Clean close propagation (stdio <-> socket)
+- [ ] Exit codes mapped to failure modes
+- [ ] Example Zed `settings.json` block
+EOF
+
+issue "Implement mux-agentd: WebSocket daemon (plus stdio mode)" \
+      "area/network,area/acp,type/enhancement,priority/P1" "$M_NET" <<'EOF'
+Deliver a remote agent daemon:
+- [ ] New bin: `mux-agentd` under `crates/mux-cli/src/bin/`
+- [ ] `--listen 0.0.0.0:7777` WebSocket server
+- [ ] One WS connection = one ACP session
+- [ ] Optional stdio mode for local runs
+- [ ] Graceful shutdown & draining
+EOF
+
+issue "TLS and authentication for the relay path" \
+      "area/network,area/security,type/enhancement,priority/P1" "$M_NET" <<'EOF'
+Secure the network link:
+- [ ] TLS via rustls (wss://)
+- [ ] Token auth (header or Sec-WebSocket-Protocol)
+- [ ] Optional mTLS (client certs)
+- [ ] Secret reload without restart (SIGHUP or config hot-reload)
+EOF
+
+issue "Heartbeats, reconnect, and bounded buffers" \
+      "area/network,area/acp,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+Reliability primitives:
+- [ ] WS ping/pong every 20s with timeout
+- [ ] Exponential backoff reconnect in `mux-cli-relay`
+- [ ] Bounded channels between stdio and WS tasks
+- [ ] Pause reads if peer is slow; drop/merge low-priority logs under pressure
+EOF
+
+issue "Config & flags for networking (relay/daemon, limits)" \
+      "area/network,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+User-facing configuration:
+- [ ] Flags: `--relay`, `--listen`, timeouts, max-frame size
+- [ ] Env var overrides and config validation
+- [ ] Helpful error messages
+EOF
+
+issue "Docs: docs/networking.md + Zed examples" \
+      "area/docs,area/network,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+Documentation:
+- [ ] Topology diagrams (local vs relay)
+- [ ] Zed `settings.json` examples
+- [ ] Security notes (TLS, tokens, mTLS)
+- [ ] Troubleshooting (firewalls, certs, reconnects)
+EOF
+
+issue "Integration tests for relay and daemon" \
+      "area/network,area/telemetry,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+Test coverage:
+- [ ] Loopback relay <-> daemon happy path
+- [ ] Close mid-stream (client and server) with clean teardown
+- [ ] Latency/jitter recording; assert no unbounded growth
+- [ ] CI job to spin up ephemeral WS server and run tests
+EOF
+
+issue "Telemetry for sessions: tracing & metrics" \
+      "area/telemetry,area/network,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+Observability:
+- [ ] Tracing spans with session IDs
+- [ ] Metrics: active sessions, bytes in/out, reconnects, heartbeat failures
+- [ ] JSON logs with token/header redaction
+EOF
+
+issue "Security hardening: workspace allowlists & path guards" \
+      "area/security,area/network,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+Hardening:
+- [ ] Workspace root allowlist on server
+- [ ] Path normalization & traversal protections
+- [ ] (Optional) chroot/namespace sandbox feature gate
+EOF
+
+echo "==> Done. 🎯"

--- a/script/gh-networking-issues.sh
+++ b/script/gh-networking-issues.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${REPO:-qapish/mux}"
+M_NET="Networking & Remote Agents"
+
+echo "==> Target repo: $REPO"
+
+upsert_label () {
+  local name="$1" color="$2" desc="${3:-}"
+  if gh label create "$name" -R "$REPO" --color "$color" --description "$desc" >/dev/null 2>&1; then
+    echo "Created label: $name"
+  else
+    gh label edit "$name" -R "$REPO" --color "$color" ${desc:+--description "$desc"} >/dev/null
+    echo "Updated label: $name"
+  fi
+}
+
+ensure_milestone () {
+  local title="$1" desc="${2:-}" state="${3:-open}"
+  local found
+  found="$(gh api -X GET -F state=all "repos/${REPO}/milestones" --jq ".[] | select(.title==\"${title}\") | .title" || true)"
+  if [[ -z "$found" ]]; then
+    gh api -X POST "repos/${REPO}/milestones" \
+      -f title="$title" -f state="$state" -f description="$desc" --silent >/dev/null
+    echo "Created milestone: $title"
+  else
+    echo "Milestone exists: $title"
+  fi
+}
+
+issue () {
+  local title="$1"; shift
+  local labels_csv="$1"; shift
+  local milestone_title="$1"; shift
+
+  ensure_milestone "$milestone_title"
+
+  local label_args=()
+  IFS=',' read -ra LBL <<<"$labels_csv"
+  for l in "${LBL[@]}"; do [[ -n "$l" ]] && label_args+=(-l "$l"); done
+
+  gh issue create -R "$REPO" -t "$title" \
+    --milestone "$milestone_title" \
+    "${label_args[@]}" \
+    -b "$(cat)"
+}
+
+echo "==> Ensuring labels..."
+upsert_label "area/acp"       "ededed" "ACP protocol + stdio transport"
+upsert_label "area/network"   "ededed" "Relay, sockets, WS/TCP"
+upsert_label "area/telemetry" "ededed" "Tracing, metrics, logs"
+upsert_label "area/security"  "ededed" "Auth, TLS, sandboxing"
+upsert_label "area/docs"      "ededed" "Docs & examples"
+upsert_label "type/enhancement" "84b6eb" "Feature work"
+upsert_label "priority/P1"      "e11d21" "High urgency"
+upsert_label "priority/P2"      "eb6420" "Medium"
+
+echo "==> Ensuring milestone..."
+ensure_milestone "$M_NET" "Remote agent support: relay (stdio⇄WebSocket/TCP), agent daemon, reliability & security"
+
+echo "==> Creating issues..."
+
+issue "Relay client in mux-cli: stdio ⇄ WebSocket/TCP" \
+      "area/network,area/acp,type/enhancement,priority/P1" "$M_NET" <<'EOF'
+Implement a relay mode in `mux-cli`:
+- [ ] `--relay <ws://|wss://|tcp://>` flag
+- [ ] Line-delimited JSON framing both directions
+- [ ] Clean close propagation (stdio <-> socket)
+- [ ] Basic error handling; exit codes mapped to failure modes
+EOF
+
+issue "Agent daemon mux-agentd: accept WebSocket and stdio" \
+      "area/network,area/acp,type/enhancement,priority/P1" "$M_NET" <<'EOF'
+Deliver a remote agent daemon:
+- [ ] `--listen 0.0.0.0:7777` WebSocket server
+- [ ] Optional stdio mode for local runs
+- [ ] Session lifecycle (one WS == one ACP session)
+- [ ] Graceful shutdown & draining
+EOF
+
+issue "TLS & authentication for WebSocket relay" \
+      "area/network,area/security,type/enhancement,priority/P1" "$M_NET" <<'EOF'
+Secure the relay:
+- [ ] `wss://` via rustls
+- [ ] Token auth (header or Sec-WebSocket-Protocol)
+- [ ] Optional mTLS support
+- [ ] Rotate secrets without restart (SIGHUP/reload)
+EOF
+
+issue "Heartbeats & reconnect/backoff in relay" \
+      "area/network,area/acp,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+Improve reliability:
+- [ ] WS ping/pong every 20s; drop on timeout
+- [ ] Exponential backoff reconnect in `mux-cli --relay`
+- [ ] Bound buffers to prevent unbounded memory growth
+- [ ] Health endpoint in daemon
+EOF
+
+issue "Backpressure & flow control between stdio and socket" \
+      "area/network,area/acp,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+Flow control:
+- [ ] Bounded channels between stdio and WS tasks
+- [ ] Pause reads if peer is slow
+- [ ] Drop/merge low-priority logs when congested (configurable)
+- [ ] Tests for head-of-line blocking scenarios
+EOF
+
+issue "Config & flags: networking options" \
+      "area/network,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+Add configuration:
+- [ ] `--relay`, `--listen`, timeouts, max-frame size
+- [ ] Env overrides
+- [ ] Config validation + helpful errors
+EOF
+
+issue "Docs: networking.md and Zed examples" \
+      "area/docs,area/network,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+Author documentation:
+- [ ] `docs/networking.md` (topology, flags, security)
+- [ ] Zed `settings.json` examples (local vs relay)
+- [ ] Troubleshooting guide (firewalls, certs)
+EOF
+
+issue "Tests: integration for relay & daemon" \
+      "area/network,area/telemetry,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+Integration tests:
+- [ ] Loopback relay (client <-> server) happy path
+- [ ] Drop/close mid-stream, ensure recovery
+- [ ] Latency/jitter tracking & assertions
+EOF
+
+issue "Telemetry for sessions: metrics and tracing" \
+      "area/telemetry,area/network,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+Observability:
+- [ ] Tracing spans with session IDs
+- [ ] Metrics: active sessions, bytes in/out, reconnects
+- [ ] JSON logs with redaction for headers/tokens
+EOF
+
+issue "Security hardening: directory allowlists & sandbox" \
+      "area/security,area/network,type/enhancement,priority/P2" "$M_NET" <<'EOF'
+Hardening:
+- [ ] Workspace root allowlist on server
+- [ ] Path normalization & traversal protections
+- [ ] (Optional) chroot/namespace sandbox (feature-gated)
+EOF
+
+echo "==> Done. 🎯"


### PR DESCRIPTION
This PR introduces:

- **docs/networking.md** and Zed config examples (`examples/zed/`)
- **mux-cli-relay** (stdio ⇄ WebSocket/TCP) scaffold
- **mux-agentd** (WebSocket listener) scaffold
- Compile fixes (anyhow Ok turbofish, LinesCodec typing, unused imports)

**Closes:** #34

**Touches / relates to (not closing):** #28, #29, #31, #32, #30

**Notes**
- Relay and daemon are scaffolds (echo loop) to be wired to ACP core in follow-ups.
- Heartbeats/reconnect (#31), backpressure (#32), TLS/auth (#30) tracked separately.
